### PR TITLE
v0.1.1: Config schema and runtime DI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.1] - 2026-02-07
+
+### Added
+- Zod config schema (`src/config.ts`) with asteriskApiUrl, fromNumber, defaultEndpoint, inboundPolicy, serve, etc.
+- Runtime DI module (`src/runtime.ts`) with `setVoiceCallRuntime()` / `getVoiceCallRuntime()`
+- Type definitions (`src/types.ts`) for call records, events, and API responses
+- AsteriskApiClient (`src/client.ts`) wrapping all asterisk-api REST endpoints
+- `.gitignore` for node_modules and dist
+- Updated `index.ts` to follow openclaw-bitrix24 plugin registration pattern
+
 ## [0.1.0] - 2026-02-07
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -1,21 +1,43 @@
-// OpenClaw Voice Call Plugin for FreePBX/Asterisk
-// This plugin connects OpenClaw to Asterisk via the asterisk-api bridge service.
-//
-// TODO: Implement following the openclaw-bitrix24 plugin patterns:
-// - Plugin registration with configSchema
-// - Voice call tool (initiate_call, continue_call, speak_to_user, end_call, get_status)
-// - CLI commands (voicecall call, continue, speak, end, status, tail)
-// - Gateway RPC methods (voicecall.initiate, voicecall.continue, etc.)
-// - Webhook handler for asterisk-api callbacks
-// - Call state tracking
-// - TTS integration via api.runtime.tts.textToSpeechTelephony()
+/**
+ * Voice Call FreePBX/Asterisk Plugin - Entry Point
+ * Registers the plugin with OpenClaw
+ *
+ * @module openclaw-voice-call
+ */
 
-export default {
-  id: "voice-call-freepbx",
-  name: "Voice Call (FreePBX/Asterisk)",
-  description: "Voice calling via Asterisk/FreePBX using ARI",
-  configSchema: {},
-  register(api: any) {
-    console.log("[voice-call-freepbx] Plugin registered (stub)");
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+import {
+  VoiceCallFreepbxConfigSchema,
+  type VoiceCallFreepbxConfig,
+} from "./src/config.js";
+import { setVoiceCallRuntime } from "./src/runtime.js";
+
+const voiceCallConfigSchema = {
+  parse(value: unknown): VoiceCallFreepbxConfig {
+    const raw =
+      value && typeof value === "object" && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : {};
+    return VoiceCallFreepbxConfigSchema.parse(raw);
   },
 };
+
+const plugin = {
+  id: "voice-call-freepbx",
+  name: "Voice Call (FreePBX/Asterisk)",
+  description:
+    "Voice calling via Asterisk/FreePBX using ARI and the asterisk-api bridge",
+  configSchema: voiceCallConfigSchema,
+  register(api: OpenClawPluginApi) {
+    setVoiceCallRuntime(api.runtime);
+
+    const config = voiceCallConfigSchema.parse(api.pluginConfig);
+
+    api.logger.info(
+      `[voice-call-freepbx] Plugin registered — asterisk-api at ${config.asteriskApiUrl}`,
+    );
+  },
+};
+
+export default plugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-voice-freepbx",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "OpenClaw voice call plugin for Asterisk/FreePBX via ARI",
   "main": "index.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,153 @@
+/**
+ * Asterisk-API REST Client
+ * Wraps fetch calls to the asterisk-api bridge service endpoints
+ *
+ * @module client
+ */
+
+import type {
+  HealthResponse,
+  OriginateResponse,
+  CallStatusResponse,
+  ListCallsResponse,
+  PlayMediaResponse,
+  RecordingResponse,
+  HangupResponse,
+  DtmfResponse,
+} from "./types.js";
+
+export interface AsteriskApiClientOptions {
+  /** Base URL of the asterisk-api service (e.g. "http://localhost:3456") */
+  baseUrl: string;
+
+  /** Optional API key for authentication */
+  apiKey?: string;
+}
+
+export class AsteriskApiClient {
+  private baseUrl: string;
+  private apiKey?: string;
+
+  constructor({ baseUrl, apiKey }: AsteriskApiClientOptions) {
+    // Strip trailing slash
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+    this.apiKey = apiKey;
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    };
+    if (this.apiKey) {
+      h["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+    return h;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const init: RequestInit = {
+      method,
+      headers: this.headers(),
+    };
+    if (body !== undefined) {
+      init.body = JSON.stringify(body);
+    }
+
+    const response = await fetch(url, init);
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `asterisk-api ${method} ${path} failed: ${response.status} ${response.statusText}${text ? ` — ${text}` : ""}`,
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API methods
+  // -------------------------------------------------------------------------
+
+  /** GET /health — check asterisk-api and ARI connectivity */
+  async health(): Promise<HealthResponse> {
+    return this.request<HealthResponse>("GET", "/health");
+  }
+
+  /** POST /calls — originate a new call */
+  async originate(
+    endpoint: string,
+    callerId: string,
+    timeout?: number,
+  ): Promise<OriginateResponse> {
+    return this.request<OriginateResponse>("POST", "/calls", {
+      endpoint,
+      callerId,
+      ...(timeout != null ? { timeout } : {}),
+    });
+  }
+
+  /** GET /calls/:id — get current call status */
+  async getCall(callId: string): Promise<CallStatusResponse> {
+    return this.request<CallStatusResponse>(
+      "GET",
+      `/calls/${encodeURIComponent(callId)}`,
+    );
+  }
+
+  /** GET /calls — list all active calls */
+  async listCalls(): Promise<ListCallsResponse> {
+    return this.request<ListCallsResponse>("GET", "/calls");
+  }
+
+  /** POST /calls/:id/play — play media into a call */
+  async playMedia(
+    callId: string,
+    media: string,
+  ): Promise<PlayMediaResponse> {
+    return this.request<PlayMediaResponse>(
+      "POST",
+      `/calls/${encodeURIComponent(callId)}/play`,
+      { media },
+    );
+  }
+
+  /** POST /calls/:id/record — start recording a call */
+  async startRecording(
+    callId: string,
+    opts?: { format?: string; maxDuration?: number; beep?: boolean },
+  ): Promise<RecordingResponse> {
+    return this.request<RecordingResponse>(
+      "POST",
+      `/calls/${encodeURIComponent(callId)}/record`,
+      opts ?? {},
+    );
+  }
+
+  /** DELETE /calls/:id — hang up a call */
+  async hangup(callId: string): Promise<HangupResponse> {
+    return this.request<HangupResponse>(
+      "DELETE",
+      `/calls/${encodeURIComponent(callId)}`,
+    );
+  }
+
+  /** POST /calls/:id/dtmf — send DTMF tones */
+  async sendDtmf(callId: string, dtmf: string): Promise<DtmfResponse> {
+    return this.request<DtmfResponse>(
+      "POST",
+      `/calls/${encodeURIComponent(callId)}/dtmf`,
+      { dtmf },
+    );
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,48 @@
+/**
+ * Voice Call FreePBX plugin configuration schema and types
+ *
+ * @module config
+ */
+
+import { z } from "zod";
+
+export const VoiceCallFreepbxConfigSchema = z.object({
+  /** Base URL of the asterisk-api bridge service */
+  asteriskApiUrl: z.string().url().default("http://localhost:3456"),
+
+  /** Optional API key for authenticating with asterisk-api */
+  asteriskApiKey: z.string().optional(),
+
+  /** Outbound caller ID in E.164 format */
+  fromNumber: z.string().regex(/^\+[1-9]\d{1,14}$/, "Must be E.164 format"),
+
+  /** Default destination number in E.164 format */
+  toNumber: z
+    .string()
+    .regex(/^\+[1-9]\d{1,14}$/, "Must be E.164 format")
+    .optional(),
+
+  /** Default SIP endpoint for originating calls (e.g. "PJSIP/101") */
+  defaultEndpoint: z.string().default("PJSIP/101"),
+
+  /** Inbound call policy */
+  inboundPolicy: z.enum(["disabled", "allowlist"]).default("disabled"),
+
+  /** List of allowed inbound caller IDs (used when inboundPolicy is "allowlist") */
+  allowFrom: z.array(z.string()).default([]),
+
+  /** Webhook server configuration for receiving asterisk-api callbacks */
+  serve: z
+    .object({
+      port: z.number().int().min(1).max(65535).default(3457),
+      path: z.string().default("/voice/webhook"),
+    })
+    .default({}),
+
+  /** Public URL for webhook callbacks (if behind NAT/tunnel) */
+  publicUrl: z.string().url().optional(),
+});
+
+export type VoiceCallFreepbxConfig = z.infer<
+  typeof VoiceCallFreepbxConfigSchema
+>;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,23 @@
+/**
+ * Runtime dependency injection for Voice Call FreePBX plugin
+ * Allows the plugin to access OpenClaw runtime services
+ *
+ * @module runtime
+ */
+
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setVoiceCallRuntime(rt: PluginRuntime): void {
+  runtime = rt;
+}
+
+export function getVoiceCallRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error(
+      "VoiceCall runtime not initialized. Did you call register()?",
+    );
+  }
+  return runtime;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,120 @@
+/**
+ * Voice Call FreePBX Plugin Types
+ * Type definitions for call records, events, and API responses
+ *
+ * @module types
+ */
+
+// ---------------------------------------------------------------------------
+// Call state
+// ---------------------------------------------------------------------------
+
+export type CallStatus =
+  | "initiated"
+  | "ringing"
+  | "answered"
+  | "busy"
+  | "no-answer"
+  | "failed"
+  | "hangup";
+
+export type CallDirection = "outbound" | "inbound";
+
+export interface CallRecord {
+  /** Unique call identifier returned by asterisk-api */
+  callId: string;
+
+  /** SIP endpoint (e.g. "PJSIP/101") */
+  endpoint: string;
+
+  /** Caller ID sent with the call */
+  callerId: string;
+
+  /** Current call status */
+  status: CallStatus;
+
+  /** Call direction */
+  direction: CallDirection;
+
+  /** ISO-8601 timestamp when the call was created */
+  createdAt: string;
+
+  /** ISO-8601 timestamp of the last status update */
+  updatedAt: string;
+
+  /** Asterisk channel identifier (if available) */
+  channelId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Asterisk-API REST responses
+// ---------------------------------------------------------------------------
+
+export interface HealthResponse {
+  status: string;
+  uptime?: number;
+  ari?: { connected: boolean };
+}
+
+export interface OriginateResponse {
+  callId: string;
+  channel: string;
+  status: string;
+}
+
+export interface CallStatusResponse {
+  callId: string;
+  status: string;
+  channel?: string;
+  duration?: number;
+  caller?: string;
+  callee?: string;
+}
+
+export interface PlayMediaResponse {
+  playbackId: string;
+  status: string;
+}
+
+export interface RecordingResponse {
+  recordingId: string;
+  status: string;
+  format?: string;
+}
+
+export interface HangupResponse {
+  callId: string;
+  status: string;
+}
+
+export interface DtmfResponse {
+  callId: string;
+  digits: string;
+  status: string;
+}
+
+export interface ListCallsResponse {
+  calls: CallStatusResponse[];
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket events from asterisk-api /events
+// ---------------------------------------------------------------------------
+
+export type AsteriskEventType =
+  | "call.started"
+  | "call.ringing"
+  | "call.answered"
+  | "call.ended"
+  | "call.dtmf"
+  | "playback.started"
+  | "playback.finished"
+  | "recording.started"
+  | "recording.finished";
+
+export interface AsteriskEvent {
+  type: AsteriskEventType;
+  callId: string;
+  timestamp: string;
+  data?: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- Add Zod config schema for plugin configuration (asteriskApiUrl, fromNumber, defaultEndpoint, inboundPolicy, serve, etc.)
- Add runtime DI module with setVoiceCallRuntime/getVoiceCallRuntime following openclaw-bitrix24 pattern
- Add type definitions for call records, events, and API responses
- Add AsteriskApiClient wrapping all asterisk-api REST endpoints
- Update index.ts to use proper plugin registration pattern
- Add .gitignore

## Test plan
- [ ] Verify config schema validates correct values and rejects invalid ones
- [ ] Verify AsteriskApiClient methods match asterisk-api endpoints
- [ ] Verify runtime DI throws when not initialized

🤖 Generated with [Claude Code](https://claude.com/claude-code)