### PR TITLE
v0.1.3: CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.3] - 2026-02-07
+
+### Added
+- CLI commands (`src/cli.ts`) under `voicecall` namespace via `api.registerCli`
+- Commands: `voicecall call`, `voicecall status`, `voicecall end`, `voicecall speak`, `voicecall list`, `voicecall health`
+- Each command creates an AsteriskApiClient and outputs formatted JSON
+- Wired CLI registration into `index.ts` register() function
+
 ## [0.1.2] - 2026-02-07
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ import {
 } from "./src/config.js";
 import { setVoiceCallRuntime } from "./src/runtime.js";
 import { registerVoiceCallTool } from "./src/tool.js";
+import { registerVoiceCallCli } from "./src/cli.js";
 
 const voiceCallConfigSchema = {
   parse(value: unknown): VoiceCallFreepbxConfig {
@@ -37,6 +38,13 @@ const plugin = {
 
     // Register voice_call tool for LLM agent use
     registerVoiceCallTool(api, config);
+
+    // Register CLI commands under `voicecall` namespace
+    api.registerCli(
+      ({ program }) =>
+        registerVoiceCallCli({ program, config, logger: api.logger }),
+      { commands: ["voicecall"] },
+    );
 
     api.logger.info(
       `[voice-call-freepbx] Plugin registered — asterisk-api at ${config.asteriskApiUrl}`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-voice-freepbx",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "OpenClaw voice call plugin for Asterisk/FreePBX via ARI",
   "main": "index.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,196 @@
+/**
+ * Voice Call CLI Commands
+ * Registers CLI commands under the `voicecall` namespace using Commander.js
+ *
+ * @module cli
+ */
+
+import type { Command } from "commander";
+
+import { AsteriskApiClient } from "./client.js";
+import type { VoiceCallFreepbxConfig } from "./config.js";
+
+type Logger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+};
+
+export function registerVoiceCallCli(params: {
+  program: Command;
+  config: VoiceCallFreepbxConfig;
+  logger: Logger;
+}): void {
+  const { program, config, logger } = params;
+
+  const createClient = () =>
+    new AsteriskApiClient({
+      baseUrl: config.asteriskApiUrl,
+      apiKey: config.asteriskApiKey,
+    });
+
+  const root = program
+    .command("voicecall")
+    .description("Voice call utilities for FreePBX/Asterisk");
+
+  // -------------------------------------------------------------------------
+  // voicecall call
+  // -------------------------------------------------------------------------
+  root
+    .command("call")
+    .description("Originate an outbound voice call")
+    .requiredOption(
+      "-m, --message <text>",
+      "Message to speak when call connects",
+    )
+    .option(
+      "-t, --to <endpoint>",
+      "SIP endpoint to call (e.g. PJSIP/102); defaults to config defaultEndpoint",
+    )
+    .option(
+      "--caller-id <id>",
+      "Caller ID override (E.164); defaults to config fromNumber",
+    )
+    .action(
+      async (options: {
+        message: string;
+        to?: string;
+        callerId?: string;
+      }) => {
+        try {
+          const client = createClient();
+          const endpoint = options.to ?? config.defaultEndpoint;
+          const callerId = options.callerId ?? config.fromNumber;
+
+          const result = await client.originate(endpoint, callerId);
+          // eslint-disable-next-line no-console
+          console.log(
+            JSON.stringify(
+              {
+                callId: result.callId,
+                endpoint,
+                callerId,
+                message: options.message,
+                status: result.status,
+              },
+              null,
+              2,
+            ),
+          );
+        } catch (err) {
+          logger.error(
+            `[voicecall call] ${err instanceof Error ? err.message : String(err)}`,
+          );
+          process.exitCode = 1;
+        }
+      },
+    );
+
+  // -------------------------------------------------------------------------
+  // voicecall status
+  // -------------------------------------------------------------------------
+  root
+    .command("status")
+    .description("Get call status")
+    .requiredOption("--call-id <id>", "Call ID to query")
+    .action(async (options: { callId: string }) => {
+      try {
+        const client = createClient();
+        const call = await client.getCall(options.callId);
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(call, null, 2));
+      } catch (err) {
+        logger.error(
+          `[voicecall status] ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exitCode = 1;
+      }
+    });
+
+  // -------------------------------------------------------------------------
+  // voicecall end
+  // -------------------------------------------------------------------------
+  root
+    .command("end")
+    .description("Hang up an active call")
+    .requiredOption("--call-id <id>", "Call ID to hang up")
+    .action(async (options: { callId: string }) => {
+      try {
+        const client = createClient();
+        const result = await client.hangup(options.callId);
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(result, null, 2));
+      } catch (err) {
+        logger.error(
+          `[voicecall end] ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exitCode = 1;
+      }
+    });
+
+  // -------------------------------------------------------------------------
+  // voicecall speak
+  // -------------------------------------------------------------------------
+  root
+    .command("speak")
+    .description("Play audio/message into an active call")
+    .requiredOption("--call-id <id>", "Call ID")
+    .requiredOption("--message <msg>", "Message or media URI to play")
+    .action(async (options: { callId: string; message: string }) => {
+      try {
+        const client = createClient();
+        // For now, play as media URI; TTS pipeline comes later
+        const result = await client.playMedia(
+          options.callId,
+          options.message,
+        );
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(result, null, 2));
+      } catch (err) {
+        logger.error(
+          `[voicecall speak] ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exitCode = 1;
+      }
+    });
+
+  // -------------------------------------------------------------------------
+  // voicecall list
+  // -------------------------------------------------------------------------
+  root
+    .command("list")
+    .description("List all active calls")
+    .action(async () => {
+      try {
+        const client = createClient();
+        const result = await client.listCalls();
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(result, null, 2));
+      } catch (err) {
+        logger.error(
+          `[voicecall list] ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exitCode = 1;
+      }
+    });
+
+  // -------------------------------------------------------------------------
+  // voicecall health
+  // -------------------------------------------------------------------------
+  root
+    .command("health")
+    .description("Check asterisk-api and ARI health")
+    .action(async () => {
+      try {
+        const client = createClient();
+        const result = await client.health();
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(result, null, 2));
+      } catch (err) {
+        logger.error(
+          `[voicecall health] ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exitCode = 1;
+      }
+    });
+}


### PR DESCRIPTION
## Summary
- Register CLI commands under `voicecall` namespace using Commander.js via api.registerCli
- Commands: call, status, end, speak, list, health
- Each command creates AsteriskApiClient and outputs formatted JSON

## Test plan
- [ ] Verify `voicecall call --message "test" --to PJSIP/102` originates a call
- [ ] Verify `voicecall status --call-id <id>` returns call info
- [ ] Verify `voicecall health` checks asterisk-api connectivity
- [ ] Verify `voicecall list` returns active calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)