### PR TITLE
feat(client): Add WebSocket event streaming (v0.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.1.5] - 2026-02-07
+
+### Added
+- WebSocket client in `AsteriskApiClient` for real-time event streaming
+- `connectEvents(options)` — connect to asterisk-api `/events` WebSocket
+- `disconnectEvents()` — close WebSocket connection
+- `isEventsConnected()` — check connection status
+- Auto-reconnect with configurable delay (default 3s)
+- Event types: `snapshot`, `call.created`, `call.state_changed`, `call.ready`, `call.ended`, etc.
+- `EventConnectionOptions` interface with callbacks: `onConnect`, `onDisconnect`, `onError`, `onEvent`, `onSnapshot`
+
+### Changed
+- Updated `types.ts` with full event type definitions from asterisk-api
+
 ## [0.1.4] - 2026-02-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-voice-freepbx",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "description": "OpenClaw voice call plugin for Asterisk/FreePBX via ARI",
   "main": "index.ts",
@@ -24,7 +24,9 @@
     "typescript": "^5.7.0"
   },
   "openclaw": {
-    "extensions": ["./index.ts"]
+    "extensions": [
+      "./index.ts"
+    ]
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,19 +102,55 @@ export interface ListCallsResponse {
 // ---------------------------------------------------------------------------
 
 export type AsteriskEventType =
-  | "call.started"
-  | "call.ringing"
-  | "call.answered"
-  | "call.ended"
+  | "snapshot"
+  | "call.created"
+  | "call.state_changed"
+  | "call.ready"
   | "call.dtmf"
-  | "playback.started"
-  | "playback.finished"
-  | "recording.started"
-  | "recording.finished";
+  | "call.playback_finished"
+  | "call.recording_finished"
+  | "call.ended"
+  | "call.inbound"
+  | "call.answered"
+  | "bridge.created"
+  | "bridge.destroyed";
 
 export interface AsteriskEvent {
   type: AsteriskEventType;
-  callId: string;
+  callId?: string;
   timestamp: string;
-  data?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface SnapshotEvent {
+  type: "snapshot";
+  calls: CallStatusResponse[];
+  timestamp: string;
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket connection options
+// ---------------------------------------------------------------------------
+
+export interface EventConnectionOptions {
+  /** Called when connection is established */
+  onConnect?: () => void;
+
+  /** Called when connection is closed */
+  onDisconnect?: (code: number, reason: string) => void;
+
+  /** Called on connection error */
+  onError?: (error: Error) => void;
+
+  /** Called when an event is received */
+  onEvent?: (event: AsteriskEvent) => void;
+
+  /** Called on initial snapshot */
+  onSnapshot?: (snapshot: SnapshotEvent) => void;
+
+  /** Auto-reconnect on disconnect (default: true) */
+  autoReconnect?: boolean;
+
+  /** Reconnect delay in ms (default: 3000) */
+  reconnectDelay?: number;
 }


### PR DESCRIPTION
## Changes

- Add `connectEvents(options)` for real-time event connection to asterisk-api `/events`
- Add `disconnectEvents()` and `isEventsConnected()`
- Auto-reconnect with configurable delay (default 3s)
- Full event type definitions from asterisk-api
- Callbacks: `onConnect`, `onDisconnect`, `onError`, `onEvent`, `onSnapshot`

## Version
0.1.5