### PR TITLE
feat(tool): Use event-driven state for call management (v0.1.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.1.7] - 2026-02-07
+
+### Added
+- `list_calls` action to show all active calls from WebSocket cache
+- Tool now uses EventManager for client access and call state
+- Shows `wsConnected` status in responses
+- Cache-first lookup for `get_status` (falls back to REST API)
+
+### Changed
+- `initiate_call` now takes `to` (phone number) as required param instead of optional `to` endpoint
+- Endpoint is auto-built from phone number + defaultEndpoint config
+- Tool validates call existence before `continue_call` and `speak_to_user`
+- Better error messages when calls not found
+
 ## [0.1.6] - 2026-02-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-voice-freepbx",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "description": "OpenClaw voice call plugin for Asterisk/FreePBX via ARI",
   "main": "index.ts",


### PR DESCRIPTION
## Changes

- Add `list_calls` action to show all active calls from WebSocket cache
- Use EventManager for client access and call state
- `initiate_call` now takes `to` (phone number) as required param
- Auto-build endpoint from phone number + `defaultEndpoint` config
- Validate call existence before `continue_call` and `speak_to_user`
- Cache-first lookup for `get_status` (falls back to REST API)

## Version
0.1.7