### PR TITLE
feat(config): Add outboundTrunk pattern and documentation (v0.1.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.8] - 2026-02-07
+
+### Added
+- `outboundTrunk` config option for trunk pattern with `{number}` placeholder
+- `README.md` with full setup and usage documentation
+- `TESTS.md` with comprehensive test checklist
+
+### Changed
+- `initiate_call` now uses `outboundTrunk` pattern if configured
+- Better endpoint construction logic: trunk pattern → defaultEndpoint append → fallback
+
 ## [0.1.7] - 2026-02-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,0 +1,167 @@
+# OpenClaw Voice Call Plugin (FreePBX/Asterisk)
+
+Voice calling via Asterisk/FreePBX using ARI and the asterisk-api bridge.
+
+## Features
+
+- 📞 **Outbound calls** — Initiate calls to phone numbers via OpenClaw agent
+- 🔌 **WebSocket events** — Real-time call state via asterisk-api `/events`
+- 🛡️ **Allowlist** — Restrict calls to approved numbers (at asterisk-api level)
+- 🎯 **LLM tool** — `voice_call` tool for agent use
+- 🖥️ **CLI commands** — `voicecall call`, `voicecall list`, etc.
+- 🔗 **RPC methods** — `voicecall.initiate`, `voicecall.status`, etc.
+
+## Architecture
+
+```
+OpenClaw Agent
+    ↓ voice_call tool
+openclaw-voice-call plugin
+    ↓ REST API + WebSocket
+asterisk-api (bridge service)
+    ↓ ARI
+FreePBX / Asterisk
+    ↓ SIP trunk
+PSTN / Phone
+```
+
+## Prerequisites
+
+1. **FreePBX/Asterisk** with ARI enabled
+2. **asterisk-api** bridge service running ([jaaacki/asterisk-api](https://github.com/jaaacki/asterisk-api))
+3. **OpenClaw** installed
+
+## Installation
+
+1. Clone this repo to your plugins directory:
+   ```bash
+   cd ~/Dev
+   git clone https://github.com/jaaacki/openclaw-voice-call.git
+   ```
+
+2. Add to OpenClaw config (`~/.openclaw/openclaw.json`):
+   ```json
+   {
+     "extensions": {
+       "voice-call-freepbx": {
+         "path": "~/Dev/openclaw-voice-call",
+         "config": {
+           "asteriskApiUrl": "http://localhost:3456",
+           "fromNumber": "+6512345678",
+           "outboundTrunk": "PJSIP/{number}@your-trunk-name",
+           "defaultEndpoint": "PJSIP/101"
+         }
+       }
+     }
+   }
+   ```
+
+3. Restart OpenClaw:
+   ```bash
+   openclaw gateway restart
+   ```
+
+## Configuration
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `asteriskApiUrl` | Yes | URL of asterisk-api service |
+| `asteriskApiKey` | No | API key if asterisk-api requires auth |
+| `fromNumber` | Yes | Caller ID in E.164 format (e.g., `+6512345678`) |
+| `outboundTrunk` | No | Trunk pattern with `{number}` placeholder |
+| `defaultEndpoint` | No | Default SIP endpoint (default: `PJSIP/101`) |
+| `inboundPolicy` | No | `disabled` or `allowlist` (default: `disabled`) |
+| `allowFrom` | No | Array of allowed inbound caller IDs |
+
+### Outbound Trunk Pattern
+
+The `outboundTrunk` config specifies how to dial external numbers:
+
+```json
+// Common patterns:
+"outboundTrunk": "PJSIP/{number}@trunk-provider"
+"outboundTrunk": "PJSIP/trunk-name/{number}"
+"outboundTrunk": "SIP/{number}@gateway"
+```
+
+## Usage
+
+### LLM Tool
+
+The agent can use the `voice_call` tool:
+
+```
+Call 659654255 and tell them about the meeting tomorrow.
+```
+
+### CLI Commands
+
+```bash
+# Check health
+openclaw voicecall health
+
+# List active calls
+openclaw voicecall list
+
+# Initiate a call
+openclaw voicecall call --to 659654255
+
+# Get call status
+openclaw voicecall status --call-id <id>
+
+# End a call
+openclaw voicecall end --call-id <id>
+```
+
+### Tool Actions
+
+| Action | Parameters | Description |
+|--------|------------|-------------|
+| `initiate_call` | `to`, `message?`, `mode?` | Start outbound call |
+| `speak_to_user` | `callId`, `message` | Play audio (TTS placeholder) |
+| `continue_call` | `callId`, `message` | Continue conversation |
+| `end_call` | `callId` | Hang up |
+| `get_status` | `callId` | Get call state |
+| `list_calls` | — | List all active calls |
+
+## Allowlist
+
+The allowlist is managed at the **asterisk-api** level, not in this plugin.
+
+Edit `asterisk-api/allowlist.json`:
+```json
+{
+  "inbound": ["659654255"],
+  "outbound": ["659654255"]
+}
+```
+
+Empty arrays = allow all (open mode).
+
+## Testing
+
+See [TESTS.md](./TESTS.md) for the full test checklist.
+
+Quick test:
+```bash
+# 1. Check asterisk-api is running
+curl http://localhost:3456/health
+
+# 2. Check plugin is loaded
+openclaw status
+
+# 3. Initiate test call
+openclaw voicecall call --to 659654255
+```
+
+## Roadmap
+
+- [x] V1: Outbound calls via REST + WebSocket events
+- [ ] V2: Inbound call handling
+- [ ] V2: Streaming TTS (qwen3-tts)
+- [ ] V2: Streaming STT (qwen3-asr)
+- [ ] V2: Real-time duplex conversation
+
+## License
+
+MIT

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,109 @@
+# Voice Call Plugin — Test Checklist
+
+## Prerequisites
+
+| Item | Status | Notes |
+|------|--------|-------|
+| asterisk-api running | ⬜ | `http://localhost:3456` |
+| FreePBX/Asterisk connected | ⬜ | ARI WebSocket active |
+| Plugin loaded in OpenClaw | ⬜ | Check `openclaw status` |
+| WebSocket connected | ⬜ | Check logs for "Connected to asterisk-api events" |
+| Allowlist configured | ⬜ | `659654255` in asterisk-api `allowlist.json` |
+
+## Configuration
+
+Plugin config in `~/.openclaw/openclaw.json` under `extensions.voice-call-freepbx`:
+
+```json
+{
+  "asteriskApiUrl": "http://localhost:3456",
+  "fromNumber": "+6512345678",
+  "outboundTrunk": "PJSIP/{number}@trunk-name",
+  "defaultEndpoint": "PJSIP/101"
+}
+```
+
+## Test Cases
+
+### 1. Health Check
+
+| Test | Command | Expected | Status |
+|------|---------|----------|--------|
+| CLI health | `openclaw voicecall health` | `{ status: "ok", ari: true }` | ⬜ |
+| API health | `curl localhost:3456/health` | `{ status: "ok" }` | ⬜ |
+
+### 2. WebSocket Events
+
+| Test | Expected | Status |
+|------|----------|--------|
+| Snapshot on connect | Logs show "Snapshot received: N active calls" | ⬜ |
+| Auto-reconnect | Disconnect/reconnect within 3s | ⬜ |
+
+### 3. Outbound Call (initiate_call)
+
+| Test | Command | Expected | Status |
+|------|---------|----------|--------|
+| Call to allowed number | `voice_call { action: "initiate_call", to: "659654255" }` | Call initiated, callId returned | ⬜ |
+| Call to blocked number | `voice_call { action: "initiate_call", to: "999999999" }` | 403 blocked by allowlist | ⬜ |
+| Phone rings | — | Target phone receives call | ⬜ |
+| Call state tracked | `voice_call { action: "list_calls" }` | Shows active call | ⬜ |
+
+### 4. Call Operations
+
+| Test | Command | Expected | Status |
+|------|---------|----------|--------|
+| Get status | `voice_call { action: "get_status", callId: "..." }` | Returns call details | ⬜ |
+| Speak to user | `voice_call { action: "speak_to_user", callId: "...", message: "hello" }` | Audio plays (placeholder sound) | ⬜ |
+| End call | `voice_call { action: "end_call", callId: "..." }` | Call hung up | ⬜ |
+
+### 5. List Calls
+
+| Test | Command | Expected | Status |
+|------|---------|----------|--------|
+| List active | `voice_call { action: "list_calls" }` | Array of active calls | ⬜ |
+| After hangup | `voice_call { action: "list_calls" }` | Call removed from list | ⬜ |
+
+### 6. Inbound Call (Future - V2)
+
+| Test | Expected | Status |
+|------|----------|--------|
+| Inbound from allowed | Call answered | ⬜ |
+| Inbound from blocked | Call rejected/hung up | ⬜ |
+
+## Integration Test Script
+
+```bash
+#!/bin/bash
+# Run from OpenClaw CLI or via agent
+
+# 1. Check health
+openclaw voicecall health
+
+# 2. List current calls
+openclaw voicecall list
+
+# 3. Initiate call to test number
+openclaw voicecall call --to 659654255
+
+# 4. Wait for answer, then speak
+# openclaw voicecall speak --call-id <id> --message "Hello, this is a test"
+
+# 5. End call
+# openclaw voicecall end --call-id <id>
+```
+
+## Troubleshooting
+
+| Issue | Check |
+|-------|-------|
+| "Voice call service not initialized" | Plugin not loaded, check `openclaw status` |
+| "Outbound call blocked by allowlist" | Add number to `asterisk-api/allowlist.json` |
+| No WebSocket events | Check asterisk-api is running, check firewall |
+| Call fails to originate | Check trunk config, SIP registration |
+| Audio doesn't play | Check Asterisk sounds path, format compatibility |
+
+## Sign-off
+
+| Tester | Date | Version | Result |
+|--------|------|---------|--------|
+| | | 0.1.8 | |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-voice-freepbx",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "description": "OpenClaw voice call plugin for Asterisk/FreePBX via ARI",
   "main": "index.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,16 @@ export const VoiceCallFreepbxConfigSchema = z.object({
   /** Default SIP endpoint for originating calls (e.g. "PJSIP/101") */
   defaultEndpoint: z.string().default("PJSIP/101"),
 
+  /**
+   * Outbound trunk pattern for external calls.
+   * Use {number} as placeholder for the phone number.
+   * Examples:
+   *   - "PJSIP/{number}@trunk-name" (most common)
+   *   - "PJSIP/trunk-name/{number}"
+   *   - "SIP/{number}@provider"
+   */
+  outboundTrunk: z.string().optional(),
+
   /** Inbound call policy */
   inboundPolicy: z.enum(["disabled", "allowlist"]).default("disabled"),
 

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -88,11 +88,18 @@ export function registerVoiceCallTool(
             const to = String(params.to || "").trim();
             if (!to) throw new Error("to (phone number) required");
 
-            // Build endpoint from phone number
-            // Format: PJSIP/trunk-name/number or use defaultEndpoint pattern
-            const endpoint = config.defaultEndpoint.includes("/")
-              ? `${config.defaultEndpoint}/${to}`
-              : `PJSIP/${to}`;
+            // Build endpoint from phone number using outboundTrunk pattern or defaultEndpoint
+            let endpoint: string;
+            if (config.outboundTrunk) {
+              // Use trunk pattern with {number} placeholder
+              endpoint = config.outboundTrunk.replace("{number}", to);
+            } else if (config.defaultEndpoint.includes("/")) {
+              // Append number to default endpoint
+              endpoint = `${config.defaultEndpoint}/${to}`;
+            } else {
+              // Fallback: PJSIP/number
+              endpoint = `PJSIP/${to}`;
+            }
 
             const result = await client.originate(endpoint, config.fromNumber);
 


### PR DESCRIPTION
## Changes

- Add `outboundTrunk` config option for trunk pattern with `{number}` placeholder
- Create comprehensive `README.md` with setup and usage docs
- Create `TESTS.md` test checklist
- Better endpoint construction logic in `initiate_call`

## Version
0.1.8