### PR TITLE
release: v0.2.0 — First complete release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.2.0] - 2026-02-07
+
+### Summary
+First complete release with WebSocket event streaming and outbound call support.
+
+### Features
+- ✅ WebSocket connection to asterisk-api `/events`
+- ✅ Real-time call state tracking
+- ✅ Outbound calls via `voice_call` tool
+- ✅ Trunk pattern configuration
+- ✅ CLI commands (`voicecall call`, `list`, `status`, `end`)
+- ✅ RPC methods (`voicecall.initiate`, etc.)
+- ✅ Full documentation (README.md, TESTS.md)
+
+### Breaking Changes
+- `initiate_call` now requires `to` (phone number) instead of optional endpoint override
+
 ## [0.1.8] - 2026-02-07
 
 ### Added

--- a/METHODS-MAP.md
+++ b/METHODS-MAP.md
@@ -12,7 +12,8 @@ Actions registered via `registerTool()` in `tool.ts` for LLM agent use.
 | `continue_call` | `POST /calls/:id/play` | `client.playMedia()` | V1 (placeholder — plays `sound:hello-world`, needs TTS) |
 | `speak_to_user` | `POST /calls/:id/play` | `client.playMedia()` | V1 (placeholder — plays `sound:hello-world`, needs TTS) |
 | `end_call` | `DELETE /calls/:id` | `client.hangup()` | V1 |
-| `get_status` | `GET /calls/:id` | `client.getCall()` | V1 |
+| `get_status` | `GET /calls/:id` | `client.getCall()` | V1 ✅ (cache-first) |
+| `list_calls` | — (in-memory) | `eventManager.getActiveCalls()` | V1 ✅ |
 | `answer_inbound` | — | — | V2 — accept/greet inbound call |
 | `listen` | — | — | V2 — start listening for caller speech (STT) |
 | `transfer_call` | `POST /calls/:id/transfer` | — | V2 — not in client yet |
@@ -45,7 +46,7 @@ Registered via `registerCli()` in `cli.ts`.
 | `voicecall speak` | `POST /calls/:id/play` | `client.playMedia()` | V1 |
 | `voicecall list` | `GET /calls` | `client.listCalls()` | V1 |
 | `voicecall health` | `GET /health` | `client.health()` | V1 |
-| `voicecall listen` | `WS /events` | `client.connectEvents()` | V1 — **not implemented yet** |
+| `voicecall listen` | `WS /events` | `client.connectEvents()` | V1 ✅ (via EventManager) |
 
 ## REST Client — `AsteriskApiClient`
 
@@ -129,16 +130,16 @@ Caller speaks → External Media WS → audio frames
 
 ## Event Handling
 
-### V1 — WS Event Listener (should be V1, not implemented yet)
+### V1 — WS Event Listener ✅ IMPLEMENTED
 
-The plugin should connect to asterisk-api's WS `/events` stream on startup and stay connected. This gives real-time awareness of all call events without polling.
+The plugin connects to asterisk-api's WS `/events` stream on startup and stays connected. This gives real-time awareness of all call events without polling.
 
 | Component | Description | Status |
 |-----------|-------------|--------|
-| WS connection | Connect to `ws://asterisk-api:3456/events`, auto-reconnect | V1 — **not implemented** |
-| Event router | Dispatch events by type (`call.created`, `call.state_changed`, `call.dtmf`, `call.ended`, etc.) | V1 — **not implemented** |
-| Snapshot sync | On connect, receive `snapshot` with all active calls | V1 — **not implemented** |
-| Webhook handler | HTTP POST receiver at `serve.port` / `serve.path` | V1 — config ready, **not implemented** |
+| WS connection | Connect to `ws://asterisk-api:3456/events`, auto-reconnect | V1 ✅ |
+| Event router | Dispatch events by type (`call.created`, `call.state_changed`, `call.dtmf`, `call.ended`, etc.) | V1 ✅ |
+| Snapshot sync | On connect, receive `snapshot` with all active calls | V1 ✅ |
+| Webhook handler | HTTP POST receiver at `serve.port` / `serve.path` | V2 — not implemented |
 
 **What V1 WS gives us:**
 - Know instantly when outbound call is answered/ended (no polling)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-voice-freepbx",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "type": "module",
   "description": "OpenClaw voice call plugin for Asterisk/FreePBX via ARI",
   "main": "index.ts",


### PR DESCRIPTION
## 🎉 First Complete Release

### Features
- ✅ WebSocket connection to asterisk-api `/events`
- ✅ Real-time call state tracking
- ✅ Outbound calls via `voice_call` tool
- ✅ Trunk pattern configuration (`outboundTrunk`)
- ✅ CLI commands (`voicecall call`, `list`, `status`, `end`)
- ✅ RPC methods (`voicecall.initiate`, etc.)
- ✅ Full documentation (README.md, TESTS.md)

### Breaking Changes
- `initiate_call` now requires `to` (phone number) instead of optional endpoint override

### Next Steps (V2)
- Inbound call handling
- Streaming TTS (qwen3-tts)
- Streaming STT (qwen3-asr)
- Real-time duplex conversation