### PR TITLE
fix: correct test phone number

### DIFF
--- a/CONVERSATION-LOOP.md
+++ b/CONVERSATION-LOOP.md
@@ -230,7 +230,7 @@ onTranscriptionFinal: async (callId, text, context) => {
 
 1. **Initiate Call:**
 ```bash
-openclaw voicecall call --to 659654255
+openclaw voicecall call --to 6596542555
 # Note the callId from response
 ```
 
@@ -269,7 +269,7 @@ openclaw tool voice_call '{"action": "end_call", "callId": "YOUR_CALL_ID"}'
 ### Expected Log Output
 
 ```
-[voice-call-freepbx] Call initiated to 659654255: abc123
+[voice-call-freepbx] Call initiated to 6596542555: abc123
 [EventManager] Connected to asterisk-api events
 [EventManager] Conversation mode enabled for abc123
 [EventManager] Call abc123 state: LISTENING

--- a/IMPLEMENTATION-SUMMARY.md
+++ b/IMPLEMENTATION-SUMMARY.md
@@ -148,7 +148,7 @@ Complete conversation loop implementation enabling real-time voice conversations
 - asterisk-api v0.2.1+ with transcription support
 - TTS API running at http://192.168.2.198:8101
 - FreePBX/Asterisk configured
-- Test phone number (e.g., 659654255)
+- Test phone number (e.g., 6596542555)
 
 ## Architecture Diagram
 
@@ -281,7 +281,7 @@ User speaks → Transcription (partial) → Buffer
 
 # 2. Quick smoke test
 cd ~/Dev/openclaw-freepbx/openclaw-voice-call
-openclaw tool voice_call '{"action": "initiate_call", "to": "659654255"}'
+openclaw tool voice_call '{"action": "initiate_call", "to": "6596542555"}'
 # Note the callId
 
 openclaw tool voice_call '{

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The `outboundTrunk` config specifies how to dial external numbers:
 The agent can use the `voice_call` tool:
 
 ```
-Call 659654255 and tell them about the meeting tomorrow.
+Call 6596542555 and tell them about the meeting tomorrow.
 ```
 
 ### CLI Commands
@@ -108,7 +108,7 @@ openclaw voicecall health
 openclaw voicecall list
 
 # Initiate a call
-openclaw voicecall call --to 659654255
+openclaw voicecall call --to 6596542555
 
 # Speak text into active call (server-side TTS)
 openclaw voicecall speak --call-id <id> --message "Hello, how are you?"
@@ -148,8 +148,8 @@ The allowlist is managed at the **asterisk-api** level, not in this plugin.
 Edit `asterisk-api/allowlist.json`:
 ```json
 {
-  "inbound": ["659654255"],
-  "outbound": ["659654255"]
+  "inbound": ["6596542555"],
+  "outbound": ["6596542555"]
 }
 ```
 
@@ -168,7 +168,7 @@ curl http://localhost:3456/health
 openclaw status
 
 # 3. Initiate test call
-openclaw voicecall call --to 659654255
+openclaw voicecall call --to 6596542555
 ```
 
 ## Roadmap

--- a/TEST-v0.3.0.md
+++ b/TEST-v0.3.0.md
@@ -6,7 +6,7 @@
 - [ ] TTS API running at http://192.168.2.198:8101
 - [ ] FreePBX/Asterisk configured and reachable
 - [ ] OpenClaw plugin loaded: `openclaw plugin list`
-- [ ] Test phone available (e.g., 659654255)
+- [ ] Test phone available (e.g., 6596542555)
 
 ## Test 1: Basic TTS Playback (No Transcription)
 
@@ -16,7 +16,7 @@
 # Step 1: Initiate call
 openclaw tool voice_call '{
   "action": "initiate_call",
-  "to": "659654255",
+  "to": "6596542555",
   "mode": "notify"
 }'
 
@@ -64,7 +64,7 @@ openclaw tool voice_call '{
 # Step 1: Initiate call
 openclaw tool voice_call '{
   "action": "initiate_call",
-  "to": "659654255",
+  "to": "6596542555",
   "mode": "conversation"
 }'
 
@@ -109,7 +109,7 @@ openclaw tool voice_call '{
 # Step 1: Initiate call with conversation mode
 openclaw tool voice_call '{
   "action": "initiate_call",
-  "to": "659654255",
+  "to": "6596542555",
   "mode": "conversation"
 }'
 
@@ -155,7 +155,7 @@ openclaw tool voice_call '{
 
 ```bash
 # Step 1: Start call and listening
-openclaw tool voice_call '{"action": "initiate_call", "to": "659654255"}'
+openclaw tool voice_call '{"action": "initiate_call", "to": "6596542555"}'
 openclaw tool voice_call '{"action": "start_listening", "callId": "YOUR_CALL_ID"}'
 
 # Step 2: While speaking, try to speak (should queue or ignore)
@@ -240,7 +240,7 @@ openclaw tool voice_call '{
 ls -lh /tmp/tts-*
 
 # Step 2: Run conversation
-openclaw tool voice_call '{"action": "initiate_call", "to": "659654255"}'
+openclaw tool voice_call '{"action": "initiate_call", "to": "6596542555"}'
 openclaw tool voice_call '{"action": "start_listening", "callId": "CALL_ID"}'
 # Speak several times
 
@@ -289,7 +289,7 @@ openclaw tool voice_call '{"action": "list_calls"}'
 tail -f ~/.openclaw/logs/openclaw.log | grep voice-call-freepbx
 
 # Step 3: Initiate call
-openclaw tool voice_call '{"action": "initiate_call", "to": "659654255"}'
+openclaw tool voice_call '{"action": "initiate_call", "to": "6596542555"}'
 
 # Expected log sequence:
 # - call.created event

--- a/TESTS.md
+++ b/TESTS.md
@@ -8,7 +8,7 @@
 | FreePBX/Asterisk connected | ⬜ | ARI WebSocket active |
 | Plugin loaded in OpenClaw | ⬜ | Check `openclaw status` |
 | WebSocket connected | ⬜ | Check logs for "Connected to asterisk-api events" |
-| Allowlist configured | ⬜ | `659654255` in asterisk-api `allowlist.json` |
+| Allowlist configured | ⬜ | `6596542555` in asterisk-api `allowlist.json` |
 | Qwen3-TTS model loaded | ⬜ | First speak may take 10-20s if model is idle |
 
 ## Configuration
@@ -46,7 +46,7 @@ Plugin config in `~/.openclaw/openclaw.json` under `extensions.voice-call-freepb
 
 | Test | Command | Expected | Status |
 |------|---------|----------|--------|
-| Call to allowed number | `voice_call { action: "initiate_call", to: "659654255" }` | Call initiated, callId returned | ⬜ |
+| Call to allowed number | `voice_call { action: "initiate_call", to: "6596542555" }` | Call initiated, callId returned | ⬜ |
 | Call to blocked number | `voice_call { action: "initiate_call", to: "999999999" }` | 403 blocked by allowlist | ⬜ |
 | Phone rings | — | Target phone receives call | ⬜ |
 | Call state tracked | `voice_call { action: "list_calls" }` | Shows active call | ⬜ |
@@ -112,7 +112,7 @@ openclaw voicecall health
 openclaw voicecall list
 
 # 3. Initiate call to test number
-openclaw voicecall call --to 659654255
+openclaw voicecall call --to 6596542555
 
 # 4. Wait for answer, then speak
 # openclaw voicecall speak --call-id <id> --message "Hello, this is a test"

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -19,7 +19,7 @@ import type { VoiceCallFreepbxConfig } from "./config.js";
 const VoiceCallToolSchema = Type.Union([
   Type.Object({
     action: Type.Literal("initiate_call"),
-    to: Type.String({ description: "Phone number to call (e.g. 659654255)" }),
+    to: Type.String({ description: "Phone number to call (e.g. 6596542555)" }),
     message: Type.Optional(
       Type.String({ description: "Intro message to speak when call connects" }),
     ),


### PR DESCRIPTION
## Summary
- Fix phone number typo across all docs and code: `659654255` → `6596542555` (was missing one `5`)

## Test plan
- [x] Grep confirms no remaining occurrences of wrong number

🤖 Generated with [Claude Code](https://claude.com/claude-code)