### PR TITLE
feat: streaming TTS events for asterisk-api v0.3.1 (v0.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.4.1] - 2026-02-07
+
+### Summary
+Support asterisk-api v0.3.1 streaming TTS via ExternalMedia WebSocket.
+
+### Added
+- `call.playback_stream_started`, `call.playback_stream_finished`, `call.playback_stream_error` event types and handlers
+
+### Changed
+- Updated docs to reflect streaming TTS architecture (no shared filesystem needed)
+- Requires asterisk-api v0.3.1+
+
 ## [0.4.0] - 2026-02-07
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Voice calling via Asterisk/FreePBX using ARI and the asterisk-api bridge.
 ## Features
 
 - **Outbound calls** — Initiate calls to phone numbers via OpenClaw agent
-- **Server-side TTS** — Text-to-speech via asterisk-api `POST /calls/:id/speak` (Qwen3-TTS)
+- **Server-side TTS** — Text-to-speech via asterisk-api `POST /calls/:id/speak` (Qwen3-TTS, streamed via ExternalMedia)
 - **Conversation loop** — Transcription -> agent -> TTS -> playback cycle
 - **WebSocket events** — Real-time call state via asterisk-api `/events`
 - **Allowlist** — Restrict calls to approved numbers (at asterisk-api level)
@@ -30,7 +30,7 @@ PSTN / Phone
 ## Prerequisites
 
 1. **FreePBX/Asterisk** with ARI enabled
-2. **asterisk-api v0.3.0+** bridge service running ([jaaacki/asterisk-api](https://github.com/jaaacki/asterisk-api)) — includes server-side TTS
+2. **asterisk-api v0.3.1+** bridge service running ([jaaacki/asterisk-api](https://github.com/jaaacki/asterisk-api)) — streaming TTS via ExternalMedia (no shared filesystem needed)
 3. **OpenClaw** installed
 
 ## Installation
@@ -75,7 +75,7 @@ PSTN / Phone
 | `inboundPolicy` | No | `disabled` or `allowlist` (default: `disabled`) |
 | `allowFrom` | No | Array of allowed inbound caller IDs |
 
-> **Note:** TTS configuration (`ttsApiUrl`, voice, language) is managed on the **asterisk-api** side, not in this plugin. See asterisk-api `.env` for `TTS_URL`, `TTS_DEFAULT_VOICE`, etc.
+> **Note:** TTS configuration (`ttsApiUrl`, voice, language) is managed on the **asterisk-api** side, not in this plugin. See asterisk-api `.env` for `TTS_URL`, `TTS_DEFAULT_VOICE`, etc. TTS audio is streamed to the call via ExternalMedia WebSocket — no shared filesystem or bind-mounts required between asterisk-api and Asterisk.
 
 ### Outbound Trunk Pattern
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voice-call-freepbx",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "OpenClaw voice call plugin for Asterisk/FreePBX via ARI",
   "main": "index.ts",

--- a/src/events.ts
+++ b/src/events.ts
@@ -277,6 +277,24 @@ export class VoiceCallEventManager {
         }
         break;
 
+      case "call.playback_stream_started":
+        this.logger.debug?.(
+          `[EventManager] Audio stream started on ${callId}`
+        );
+        break;
+
+      case "call.playback_stream_finished":
+        this.logger.debug?.(
+          `[EventManager] Audio stream finished on ${callId}`
+        );
+        break;
+
+      case "call.playback_stream_error":
+        if (callId) {
+          this.logger.error(`[EventManager] Audio stream error on ${callId}: ${event.error}`);
+        }
+        break;
+
       case "call.playback_finished":
         this.logger.debug?.(
           `[EventManager] Playback finished on ${callId}`

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,9 @@ export type AsteriskEventType =
   | "call.speak_started"
   | "call.speak_finished"
   | "call.speak_error"
+  | "call.playback_stream_started"
+  | "call.playback_stream_finished"
+  | "call.playback_stream_error"
   | "bridge.created"
   | "bridge.destroyed";
 


### PR DESCRIPTION
## Summary
- Add `call.playback_stream_started/finished/error` event types and handlers
- Update docs to reflect streaming ExternalMedia TTS architecture (no shared filesystem)
- Requires asterisk-api v0.3.1+

Closes #16

## Test plan
- [ ] Verify `playback_stream_started` logged during TTS speak
- [ ] Verify `playback_stream_finished` logged after TTS completes
- [ ] Verify `playback_stream_error` logged and handled on failure
- [ ] Verify no references to shared filesystem or bind-mounts remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)