### PR TITLE
fix: extract transcription fields from nested event.data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.4.2] - 2026-02-07
+
+### Summary
+Fix conversation loop: transcription events from asterisk-api use nested `data` field — plugin was reading root-level `text`/`is_final` (always undefined), so every transcription was treated as empty partial and `onTranscriptionFinal` never fired.
+
+### Fixed
+- `handleTranscription` now extracts `text`/`is_final` from `event.data` (asterisk-api's WebSocket event structure nests payload fields inside `data`)
+- Transcriptions are no longer silently discarded — final transcriptions properly trigger agent processing callback
+
+### Added
+- `call.audio_frame`, `call.audio_capture_started`, `call.audio_capture_stopped`, `call.audio_capture_error` event types
+- Event handler cases for audio capture lifecycle events
+- Suppress debug logging for high-frequency `call.audio_frame` events (was flooding logs at ~50/sec)
+
 ## [0.4.1] - 2026-02-07
 
 ### Summary

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voice-call-freepbx",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "description": "OpenClaw voice call plugin for Asterisk/FreePBX via ARI",
   "main": "index.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,10 @@ export type AsteriskEventType =
   | "call.playback_stream_started"
   | "call.playback_stream_finished"
   | "call.playback_stream_error"
+  | "call.audio_frame"
+  | "call.audio_capture_started"
+  | "call.audio_capture_stopped"
+  | "call.audio_capture_error"
   | "bridge.created"
   | "bridge.destroyed";
 


### PR DESCRIPTION
## Summary
- **Root cause**: asterisk-api WebSocket events nest payload fields inside a `data` property: `{type, callId, timestamp, data: {text, is_final}}`. The plugin read `event.text` and `event.is_final` at the root level (always `undefined`), so every transcription was treated as an empty partial and `onTranscriptionFinal` never fired — breaking the conversation loop.
- Adds `call.audio_frame`, `call.audio_capture_started/stopped/error` event types and handlers
- Suppresses high-frequency `call.audio_frame` debug logging (~50 events/sec was flooding logs)

## Test plan
- [ ] Originate call, start audio capture, speak into phone
- [ ] Verify `call.transcription` events are properly processed (Final transcription log appears)
- [ ] Verify `onTranscriptionFinal` fires and TTS echo response is heard
- [ ] Verify `call.audio_frame` events no longer flood debug logs

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)