### PR TITLE
fix: debounce-based utterance detection for ASR partial stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.4.3] - 2026-02-07
+
+### Summary
+Rewrite transcription handler with debounce-based utterance detection. asterisk-api's `is_final` only fires at call end (flush), not after each utterance — so waiting for it breaks the conversation loop. Now detects end-of-utterance by debouncing: when no new speech partials arrive for 1.5s, the buffered text is treated as a complete utterance and triggers agent processing.
+
+### Changed
+- `handleTranscription` now uses a 1.5s debounce timer on partial transcriptions instead of waiting for `is_final`
+- Extracted `processUtterance()` and `clearUtteranceTimer()` helper methods
+- Added `utteranceTimer` to `ConversationContext` type
+- `is_final` events (call-end flush) still processed as fallback for any remaining buffer
+
 ## [0.4.2] - 2026-02-07
 
 ### Summary

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voice-call-freepbx",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "OpenClaw voice call plugin for Asterisk/FreePBX via ARI",
   "main": "index.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,8 +166,11 @@ export interface ConversationContext {
   /** Current conversation state */
   state: ConversationState;
 
-  /** Buffered partial transcription */
+  /** Buffered partial transcription (latest non-empty partial) */
   partialText: string;
+
+  /** Debounce timer for detecting end-of-utterance from partial stream */
+  utteranceTimer?: ReturnType<typeof setTimeout>;
 
   /** Full conversation history */
   history: Array<{ role: "user" | "assistant"; content: string; timestamp: string }>;


### PR DESCRIPTION
## Summary
- asterisk-api's `is_final` only fires at call end (flush), not after each utterance — waiting for it broke the conversation loop entirely
- Now uses a 1.5s debounce timer on partial transcriptions: when no new speech partials arrive for 1.5s, the buffered text is treated as a complete utterance and triggers `onTranscriptionFinal`
- `is_final` still handled as fallback for any remaining buffer at call end
- Added `utteranceTimer` to `ConversationContext`, cleanup on call end

## Test plan
- [ ] Originate call, start audio capture, speak into phone
- [ ] Verify "Utterance complete" log appears ~1.5s after you stop speaking
- [ ] Verify TTS echo response plays back what you said
- [ ] Verify subsequent utterances also trigger responses (multi-turn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)