### PR TITLE
fix: filter ASR noise hallucinations from utterance detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.4.4] - 2026-02-07
+
+### Summary
+Filter ASR noise hallucinations from utterance detection. The ASR model sends short hallucinated words ("Okay.", "The.", "Oh.") during silence at ~800ms intervals, preventing the debounce timer from ever firing. Now filters noise by requiring a minimum word count (3+ words) before starting the debounce timer, and ignoring short partials that don't grow the text buffer.
+
+### Changed
+- `handleTranscription` now filters noise partials: short text (< 3 words) that doesn't grow the buffer is ignored
+- Debounce timer only starts/resets when partial text reaches 3+ words
+- Buffer preserves the longest text seen — noise can't overwrite substantial speech
+- Added `MIN_UTTERANCE_WORDS` constant (3) for noise threshold
+- Debug logs now show word count per partial and explicit "Noise filtered" messages
+
+### Known Limitations
+- Single-word and two-word responses (e.g., "Yes", "No") won't trigger utterance detection mid-call — only processed at call end via `is_final`
+- Long-term fix requires ASR-side VAD/endpointing improvements
+
 ## [0.4.3] - 2026-02-07
 
 ### Summary

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voice-call-freepbx",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "description": "OpenClaw voice call plugin for Asterisk/FreePBX via ARI",
   "main": "index.ts",


### PR DESCRIPTION
## Summary
- Filter ASR noise: short hallucinated partials ("Okay.", "The.", "Oh.") during silence no longer reset the debounce timer
- Require 3+ words before starting utterance debounce timer
- Preserve longest text in buffer — noise can't overwrite real speech
- Debug logs show word count and explicit noise filtering

## Known Limitations
- Single/two-word responses won't trigger mid-call (only at call end `is_final`)
- Long-term fix: ASR-side VAD/endpointing

Closes #20

## Test plan
- [ ] Originate call, speak multi-word sentence, verify utterance detection fires after 1.5s silence
- [ ] Verify noise partials ("Okay.", "The.") are filtered in logs as "Noise filtered"
- [ ] Verify TTS echo response plays back after utterance detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)